### PR TITLE
handling error when url is incorrect

### DIFF
--- a/src/lib/download_manager.rs
+++ b/src/lib/download_manager.rs
@@ -1,6 +1,6 @@
 use crate::lib::{
     downloader::{parallel::ParallelDownloader, single::SingleDownloader},
-    utils::{is_accept_ranges, Download},
+    utils::{is_accept_ranges, Download, RugetError},
 };
 
 pub struct DownloadManager {
@@ -8,14 +8,15 @@ pub struct DownloadManager {
 }
 
 impl DownloadManager {
-    pub fn new(url: String, output_path: Option<String>) -> Self {
+    pub fn new(url: String, output_path: Option<String>) -> Result<Self,RugetError> {
+
         let downloader: Box<dyn Download> = {
-            if is_accept_ranges(&url) {
+            if is_accept_ranges(&url)? {
                 Box::new(ParallelDownloader::new(url, output_path))
             } else {
                 Box::new(SingleDownloader::new(url, output_path))
             }
         };
-        Self { downloader }
+        Ok( Self { downloader } )
     }
 }

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -1,15 +1,32 @@
 use reqwest::{header::ACCEPT_RANGES, Client};
 
+pub enum RugetError {
+    ClientBuiltError,
+    ClientExecuteError,
+}
+
 pub fn get_file_size(b: f32) -> String {
     format!("{:.2} MB", b / 1000000.0)
 }
 
-pub fn is_accept_ranges(url: &str) -> bool {
+pub fn is_accept_ranges(url: &str) -> Result<bool,RugetError> {
     let client = Client::new();
-    let res = client.head(url).send().expect("head failed...");
-    match res.headers().get(ACCEPT_RANGES) {
-        Some(res) => !matches!(res.to_str().unwrap(), "none"),
-        None => false,
+
+    let request_built = client.head(url).build();
+
+    if let Err(_err) = request_built {
+        return Err(RugetError::ClientBuiltError);
+    }
+
+    let res = client.execute(request_built.unwrap());
+
+    if let Err(_err) = res {
+        return Err(RugetError::ClientExecuteError);
+    }
+
+    match res.unwrap().headers().get(ACCEPT_RANGES) {
+        Some(res) => Ok(!matches!(res.to_str().unwrap(), "none")),
+        None => Ok(false),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use seahorse::{Action, App, Flag, FlagType};
 
 use lib::download_manager::DownloadManager;
 
+use lib::utils::RugetError;
+
 const NAME: &str = "
                        _   
                       | |  
@@ -38,8 +40,15 @@ fn main() {
             Err(_) => None,
         };
 
-        let download_manager = DownloadManager::new(url.to_owned(), output);
-        download_manager.downloader.download();
+        match DownloadManager::new(url.to_owned(), output) {
+            Ok(download_manager) => download_manager.downloader.download(),
+            Err(ruget_error) => {
+                match ruget_error {
+                    RugetError::ClientBuiltError => eprintln!("Error when building client : verify your url"),
+                    RugetError::ClientExecuteError => eprintln!("Error when executing client"),
+                }
+            },
+        }
     };
 
     let app = App::new(NAME)


### PR DESCRIPTION
I do something to handle when the url is incorrect instead of crashing

by example : ruget url-incorrect

Before
`thread 'main' panicked at 'head failed...: Error(Url(RelativeUrlWithoutBase))', src/lib/utils.rs:9:39
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace`

After
`Error when building client : verify your url`

Same thing when executing client request

I know that's a bad pull request, but it help me to learn a lot about Rust :+1: 